### PR TITLE
Support Errorf and Fatalf

### DIFF
--- a/testing/t.go
+++ b/testing/t.go
@@ -42,8 +42,7 @@ func (t *T) Error(args ...any) {
 }
 
 func (t *T) Errorf(format string, args ...any) {
-	fmt.Println(format)
-	fmt.Println(args...)
+	fmt.Printf(format+"\n", args...)
 	panic("errorf")
 }
 
@@ -65,7 +64,7 @@ func (t *T) Fatal(args ...any) {
 	panic("fatal")
 }
 func (t *T) Fatalf(format string, args ...any) {
-	fmt.Println(format, args)
+	fmt.Printf(format+"\n", args...)
 	panic("fatal")
 }
 func (t *T) Helper() {


### PR DESCRIPTION
Technically the real one only adds `\n` if it isn't already there, but this is simpler and I don't think we mind an extra newline

Without this we see things like `failed to create config %v: %v [ unknown type core//]`