### PR TITLE
update go.mod dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830
-	golang.org/x/tools v0.1.13-0.20221007141809-02bef08ac854
+	golang.org/x/tools v0.2.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AdamKorcz/go-118-fuzz-build
 go 1.18
 
 require (
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830
 	golang.org/x/tools v0.1.13-0.20221007141809-02bef08ac854
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,5 @@ golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
 golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.1.13-0.20221007141809-02bef08ac854 h1:fzDvmJnoyma87dC7IBnNQWmMZNalsNrtiY1X6PwmME0=
-golang.org/x/tools v0.1.13-0.20221007141809-02bef08ac854/go.mod h1:VsjNM1dMo+Ofkp5d7y7fOdQZD8MTXSQ4w3EPk65AvKU=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
+golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72 h1:kq78byqmxX6R9uk4uN3HD2F5tkZJAZMauuLSkNPS8to=
-github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830 h1:u8scGKApGy+gXpYDw2f+nh60R0FqCfrpDRIQki+5o3U=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=


### PR DESCRIPTION
### go.mod: github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830


full diff: https://github.com/AdaLogics/go-fuzz-headers/compare/3345c89a7c72...d395f97c4830

### go.mod: golang.org/x/tools v0.2.0

Updating to use a released version, but staying on a slightly older version to not force other indirect dependencies to be updated.

