### PR TITLE
testing: implement panicky testing.B struct

### DIFF
--- a/testing/b.go
+++ b/testing/b.go
@@ -6,6 +6,25 @@ import (
 
 type B struct{}
 
+func (b *B) Cleanup(f func())                  {}
+func (b *B) Error(args ...any)                 {}
+func (b *B) Errorf(format string, args ...any) {}
+func (b *B) Fail()                             {}
+func (b *B) FailNow()                          {}
+func (b *B) Failed() bool                      { panic("not implemented") }
+func (b *B) Fatal(args ...any)                 {}
+func (b *B) Fatalf(format string, args ...any) {}
+func (b *B) Helper()                           {}
+func (b *B) Log(args ...any)                   {}
+func (b *B) Logf(format string, args ...any)   {}
+func (b *B) Name() string                      { panic("not implemented") }
+func (b *B) Setenv(key, value string)          {}
+func (b *B) Skip(args ...any)                  {}
+func (b *B) SkipNow()                          {}
+func (b *B) Skipf(format string, args ...any)  {}
+func (b *B) Skipped() bool                     { panic("not implemented") }
+func (b *B) TempDir() string                   { panic("not implemented") }
+
 func (b *B) StartTimer()                         {}
 func (b *B) StopTimer()                          {}
 func (b *B) ResetTimer()                         {}

--- a/testing/b.go
+++ b/testing/b.go
@@ -1,0 +1,17 @@
+package testing
+
+import (
+	"time"
+)
+
+type B struct{}
+
+func (b *B) StartTimer()                         {}
+func (b *B) StopTimer()                          {}
+func (b *B) ResetTimer()                         {}
+func (b *B) SetBytes(n int64)                    {}
+func (b *B) ReportAllocs()                       {}
+func (b *B) Elapsed() time.Duration              { return 0 }
+func (b *B) ReportMetric(n float64, unit string) {}
+func (b *B) Run(name string, f func(b *B)) bool  { panic("not implemented") }
+func (b *B) SetParallelism(p int)                {}

--- a/testing/interfaces.go
+++ b/testing/interfaces.go
@@ -1,0 +1,28 @@
+package testing
+
+// compile-time conformance checks
+var (
+	_ = TB((*T)(nil))
+	_ = TB((*B)(nil))
+)
+
+type TB interface {
+	Cleanup(func())
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Setenv(key, value string)
+	Skip(args ...any)
+	SkipNow()
+	Skipf(format string, args ...any)
+	Skipped() bool
+	TempDir() string
+}


### PR DESCRIPTION
Fixes https://github.com/AdamKorcz/go-118-fuzz-build/issues/16

Caveat: I haven't tested if it works, not sure what's the easiest way to do that (I suppose that there must exist easier ways than modding my whole oss-fuzz setup to use my fork). 

I took nearly all public functions of `testing.B`, except `func (b *B) RunParallel(body func(*PB))`, which would pull in yet more structs. 

I made the `Run` panic, otherwise don't see any need to make it panic. Someone might invoke `ReportAllocs` in `init` for all I know. 