### PR TITLE
update deps, coverage: fix test-failures, fix getstring

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -12,10 +12,10 @@ import (
 )
 
 type Walker struct {
-	args []string
-	fuzzerName  string
-	fset  *token.FileSet
-	src  []byte // file contents
+	args       []string
+	fuzzerName string
+	fset       *token.FileSet
+	src        []byte // file contents
 }
 
 // Main walker func to traverse a fuzz harness when obtaining
@@ -28,10 +28,10 @@ func (walker *Walker) Visit(node ast.Node) ast.Visitor {
 	case *ast.FuncDecl:
 		if n.Name.Name == walker.fuzzerName {
 			bw := &BodyWalker{
-				args: make([]string, 0),
+				args:       make([]string, 0),
 				fuzzerName: walker.fuzzerName,
-				fset: walker.fset,
-				src: walker.src,
+				fset:       walker.fset,
+				src:        walker.src,
 			}
 			ast.Walk(bw, n.Body)
 			walker.args = bw.args
@@ -41,10 +41,10 @@ func (walker *Walker) Visit(node ast.Node) ast.Visitor {
 }
 
 type BodyWalker struct {
-	args []string
-	fuzzerName  string
-	fset  *token.FileSet
-	src  []byte // file contents
+	args       []string
+	fuzzerName string
+	fset       *token.FileSet
+	src        []byte // file contents
 }
 
 func (walker *BodyWalker) Visit(node ast.Node) ast.Visitor {
@@ -97,10 +97,10 @@ func getFuzzArgs(fuzzerFileContents, fuzzerName string) ([]string, error) {
 		panic(err)
 	}
 	w := &Walker{
-		args: []string{},
+		args:       []string{},
 		fuzzerName: fuzzerName,
-		fset: fset,
-		src: []byte(fuzzerFileContents),
+		fset:       fset,
+		src:        []byte(fuzzerFileContents),
 	}
 	ast.Walk(w, f)
 	return w.args, nil
@@ -148,57 +148,58 @@ func libFuzzerSeedToGoSeed(testcase []byte, args []string) string {
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
+			fmt.Printf("string: %v\n", s)
 		case "int":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("int(%s)", strconv.Itoa(int(randInt))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
 		case "int8":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetByte()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int8(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("int8(%s)", strconv.Itoa(int(int8(randInt)))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
 		case "int16":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetUint16()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int16(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("int16(%s)", strconv.Itoa(int(int16(randInt)))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
 		case "int32":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetUint32()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int32(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("int32(%s)", strconv.Itoa(int(int32(randInt)))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
 		case "int64":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int64(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("int64(%s)", strconv.Itoa(int(int64(randInt)))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
 		case "uint":
-			randInt, err := fuzzConsumer.GetInt()
+			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint(%s)", strconv.Itoa(randInt)))
+			b.WriteString(fmt.Sprintf("uint(%s)", strconv.Itoa(int(uint(randInt)))))
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -148,7 +148,6 @@ func libFuzzerSeedToGoSeed(testcase []byte, args []string) string {
 			if argNumber != len(args)-1 {
 				b.WriteString("\n")
 			}
-			fmt.Printf("string: %v\n", s)
 		case "int":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"strconv"
 	"strings"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
@@ -128,158 +127,109 @@ func libFuzzerSeedToGoSeed(testcase []byte, args []string) string {
 
 	fuzzConsumer := fuzz.NewConsumer(testcase)
 	for argNumber, arg := range args {
-		fmt.Println(argNumber)
+		//fmt.Println(argNumber)
 		switch arg {
 		case "[]uint8", "[]byte":
 			randBytes, err := fuzzConsumer.GetBytes()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("[]byte(\"%s\")", string(randBytes)))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "[]byte(%q)", string(randBytes))
 		case "string":
 			s, err := fuzzConsumer.GetString()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("string(\"%s\")", s))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "string(%q)", string(s))
 		case "int":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int(%s)", strconv.Itoa(int(randInt))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "int(%v)", int(randInt))
 		case "int8":
 			randInt, err := fuzzConsumer.GetByte()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int8(%s)", strconv.Itoa(int(int8(randInt)))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "int8(%v)", int8(randInt))
 		case "int16":
 			randInt, err := fuzzConsumer.GetUint16()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int16(%s)", strconv.Itoa(int(int16(randInt)))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "int16(%v)", int16(randInt))
 		case "int32":
 			randInt, err := fuzzConsumer.GetUint32()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int32(%s)", strconv.Itoa(int(int32(randInt)))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "int32(%v)", int32(randInt))
 		case "int64":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("int64(%s)", strconv.Itoa(int(int64(randInt)))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "int64(%v)", int64(randInt))
 		case "uint":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint(%s)", strconv.Itoa(int(uint(randInt)))))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "uint(%v)", uint(randInt))
 		case "uint8":
 			randInt, err := fuzzConsumer.GetInt()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint8(%s)", strconv.Itoa(randInt)))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "uint8(%v)", uint8(randInt))
 		case "uint16":
 			randInt, err := fuzzConsumer.GetUint16()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint16(%d)", randInt))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "uint16(%v)", uint16(randInt))
 		case "uint32":
 			randInt, err := fuzzConsumer.GetUint32()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint32(%d)", randInt))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "uint32(%v)", uint32(randInt))
 		case "uint64":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("uint64(%d)", randInt))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "uint64(%v)", uint64(randInt))
 		case "rune":
 			randRune, err := fuzzConsumer.GetRune()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("rune(%s)", string(randRune)))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "rune(%q)", string(randRune))
 		case "float32":
 			randFloat, err := fuzzConsumer.GetFloat32()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString("float32(")
-			b.WriteString(fmt.Sprintf("%f", randFloat))
-			b.WriteString(")")
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "float32(%f)", randFloat)
 		case "float64":
 			randFloat, err := fuzzConsumer.GetFloat64()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString("float64(")
-			b.WriteString(fmt.Sprintf("%f", randFloat))
-			b.WriteString(")")
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "float64(%f)", randFloat)
 		case "bool":
 			randBool, err := fuzzConsumer.GetBool()
 			if err != nil {
 				panic(err)
 			}
-			b.WriteString(fmt.Sprintf("bool(%t)", randBool))
-			if argNumber != len(args)-1 {
-				b.WriteString("\n")
-			}
+			fmt.Fprintf(&b, "bool(%t)", randBool)
 		default:
-			panic("Fuzzer uses unsupported type")
+			panic(fmt.Sprintf("fuzzer uses unsupported type: %s", arg))
+		}
+		if argNumber != len(args)-1 {
+			fmt.Fprintln(&b, "")
 		}
 	}
 	return b.String()

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,13 +1,12 @@
 package coverage
 
 import (
-	//"fmt"
+	"encoding/binary"
 	"testing"
 )
 
 var (
-	libFuzzertestCase1 = []byte{5, 65, 68, 65, 77, 49, 4, 65, 68, 65, 77, 1, 2, 0, 65, 66, 65, 77, 49, 0, 0, 4}
-	goTestCase1        = `go test fuzz v1
+	goTestCase1 = `go test fuzz v1
 string("ADAM1")
 string("ADAM")
 int(1)
@@ -26,30 +25,45 @@ func FuzzTest(f *testing.F) {
 }`
 )
 
+// addString adds a string to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addString(input []byte, s string) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(len(s))) // Add a uint32 length
+	input = append(input, []byte(s)...)                          // Add string
+	return input
+}
+
+// addString adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addBytes(input []byte, data []byte) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(len(data))) // Add a uint32 length
+	input = append(input, data...)                                  // Add string
+	return input
+}
+
+// addString adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addU64(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint64(input, uint64(i))
+	input = append(input, 1) // endianness boolean
+	return input
+}
+
 func TestGetFuzzArgs(t *testing.T) {
 	args, err := getFuzzArgs(fuzzer1, "FuzzTest")
 	if err != nil {
 		t.Error(err)
 	}
-	if args[0] != "string" {
-		t.Log(fuzzer1)
-		t.Error("args[0] should be []byte but is not")
+	for i, want := range []string{"string", "string", "int", "[]byte"} {
+		if have := args[i]; have != want {
+			t.Errorf("args[%d] wrong: have %q want %q", i, have, want)
+		}
 	}
-	if args[1] != "string" {
-		t.Log(fuzzer1)
-		t.Error("args[0] should be []byte but is not")
-	}
-	if args[2] != "int" {
-		t.Log(fuzzer1)
-		t.Error("args[0] should be int but is not")
-	}
-	if args[3] != "[]byte" {
-		t.Log(fuzzer1)
-		t.Error("args[0] should be string but is not")
-	}
+	testdata := addString(nil, "ADAM1")
+	testdata = addString(testdata, "ADAM")
+	testdata = addU64(testdata, 1)
+	testdata = addBytes(testdata, []byte("AB"))
 
-	libFuzzerTestcase := libFuzzerSeedToGoSeed(libFuzzertestCase1, args)
-	if libFuzzerTestcase != goTestCase1 {
+	have := libFuzzerSeedToGoSeed(testdata, args)
+	if want := goTestCase1; have != want {
+		t.Logf("have\n%v\nwant\n%v\n", have, want)
 		t.Error("Failed testcase conversion")
 	}
 }

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -2,15 +2,11 @@ package coverage
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
 
 var (
-	goTestCase1 = `go test fuzz v1
-string("ADAM1")
-string("ADAM")
-int(1)
-[]byte("AB")`
 	fuzzer1 = `package fuzzpackage
 
 import (
@@ -22,7 +18,17 @@ func FuzzTest(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data1, data2 string, in int, data3 []byte) {
 		fmt.Println("HERE")
 	})
-}`
+}
+
+func FuzzTest2(f *testing.F) {
+	f.Fuzz(func(t *testing.T, 
+		a int, b int8, c int16, d int32, e int64, 
+		f uint, g uint8, h uint16, i uint32, j uint64,
+		foo string){
+		fmt.Println("HERE")
+	})
+}
+`
 )
 
 // addString adds a string to the input vector corresponding to consumer.go @ go-fuzz-headers
@@ -32,17 +38,29 @@ func addString(input []byte, s string) []byte {
 	return input
 }
 
-// addString adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
+// addBytes adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addBytes(input []byte, data []byte) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(len(data))) // Add a uint32 length
 	input = append(input, data...)                                  // Add string
 	return input
 }
 
-// addString adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
+// addU64 adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addU64(input []byte, i uint64) []byte {
-	input = binary.BigEndian.AppendUint64(input, uint64(i))
+	input = binary.BigEndian.AppendUint64(input, i)
 	input = append(input, 1) // endianness boolean
+	return input
+}
+
+func addU16(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint16(input, uint16(i))
+	input = append(input, 1) // endianness boolean
+	return input
+}
+
+func addU32(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(i))
+	// U32 doesn't use endianness boolean!
 	return input
 }
 
@@ -56,13 +74,65 @@ func TestGetFuzzArgs(t *testing.T) {
 			t.Errorf("args[%d] wrong: have %q want %q", i, have, want)
 		}
 	}
-	testdata := addString(nil, "ADAM1")
-	testdata = addString(testdata, "ADAM")
-	testdata = addU64(testdata, 1)
-	testdata = addBytes(testdata, []byte("AB"))
+	input := addString(nil, "ADAM1")
+	input = addString(input, "ADAM")
+	input = addU64(input, 1)
+	input = addBytes(input, []byte("AB"))
 
-	have := libFuzzerSeedToGoSeed(testdata, args)
-	if want := goTestCase1; have != want {
+	have := libFuzzerSeedToGoSeed(input, args)
+	want := `go test fuzz v1
+string("ADAM1")
+string("ADAM")
+int(1)
+[]byte("AB")`
+
+	if have != want {
+		t.Logf("have\n%v\nwant\n%v\n", have, want)
+		t.Error("Failed testcase conversion")
+	}
+}
+
+func TestGetFuzzArgs2(t *testing.T) {
+	args, err := getFuzzArgs(fuzzer1, "FuzzTest2")
+	if err != nil {
+		t.Error(err)
+	}
+	for i, want := range []string{"int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "string"} {
+		if have := args[i]; have != want {
+			t.Errorf("args[%d] wrong: have %q want %q", i, have, want)
+		}
+	}
+	var v int64 = -1
+	input := addU64(nil, uint64(v))         // int
+	input = append(input, byte(int8(v)))    // int8
+	input = addU16(input, uint64(int16(v))) // int16
+	input = addU32(input, uint64(int32(v))) // int32
+	input = addU64(input, uint64(int64(v))) // int64
+	fmt.Printf("input:%x\n", input)         // ffffffffffffffff01
+
+	input = addU64(input, uint64(0x1122_3344_4455_6677)) // uint
+	input = append(input, 0x11)                          // uint8
+	input = addU16(input, uint64(uint16(0x2233)))        // uint16
+	input = addU32(input, uint64(uint32(0x4455_6677)))   // uint32
+	input = addU64(input, uint64(0x1122_3344_4455_6677)) // uint64
+
+	input = addString(input, "oll korrekt")
+
+	have := libFuzzerSeedToGoSeed(input, args)
+	want := `go test fuzz v1
+int(-1)
+int8(-1)
+int16(-1)
+int32(-1)
+int64(-1)
+uint(1234605616150177399)
+uint8(17)
+uint16(8755)
+uint32(1146447479)
+uint64(1234605616150177399)
+string("oll korrekt")`
+
+	if have != want {
 		t.Logf("have\n%v\nwant\n%v\n", have, want)
 		t.Error("Failed testcase conversion")
 	}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -35,40 +35,34 @@ func FuzzTest2(f *testing.F) {
 // addString adds a string to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addString(input []byte, s string) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(len(s))) // Add a uint32 length
-	input = append(input, []byte(s)...)                          // Add string
-	return input
+	return append(input, []byte(s)...)                           // Add string
 }
 
 // addBytes adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addBytes(input []byte, data []byte) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(len(data))) // Add a uint32 length
-	input = append(input, data...)                                  // Add string
-	return input
+	return append(input, data...)                                   // Add string
 }
 
 // addU64 adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addU64(input []byte, i uint64) []byte {
 	input = binary.BigEndian.AppendUint64(input, i)
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness booleans
 }
 
 func addU16(input []byte, i uint64) []byte {
 	input = binary.BigEndian.AppendUint16(input, uint16(i))
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness boolean
 }
 
 func addU32(input []byte, i uint64) []byte {
-	input = binary.BigEndian.AppendUint32(input, uint32(i))
 	// U32 doesn't use endianness boolean! (but when used for float32, it does, sigh)
-	return input
+	return binary.BigEndian.AppendUint32(input, uint32(i))
 }
 
 func addF32(input []byte, f float32) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(math.Float32bits(f)))
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness boolean
 }
 
 func TestGetFuzzArgs(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AdamKorcz/go-118-fuzz-build
 go 1.18
 
 require (
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
 	golang.org/x/tools v0.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830 h1:u8scGKApGy+gXpYDw2f+nh60R0FqCfrpDRIQki+5o3U=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20221206110420-d395f97c4830/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=

--- a/testing/f.go
+++ b/testing/f.go
@@ -42,138 +42,109 @@ func (f *F) Fuzz(ff any) {
 	fuzzConsumer := fuzz.NewConsumer(f.Data)
 	for _, v := range types {
 		//fmt.Printf("arg %v\n", v)
+		newElem := reflect.New(v).Elem()
 		switch v.String() {
 		case "[]uint8":
 			b, err := fuzzConsumer.GetBytes()
 			if err != nil {
 				return
 			}
-			newBytes := reflect.New(v)
-			newBytes.Elem().SetBytes(b)
-			args = append(args, newBytes.Elem())
+			newElem.SetBytes(b)
 		case "string":
 			s, err := fuzzConsumer.GetString()
 			if err != nil {
 				return
 			}
-			newString := reflect.New(v)
-			newString.Elem().SetString(s)
-			args = append(args, newString.Elem())
+			newElem.SetString(s)
 		case "int":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				return
 			}
-			newInt := reflect.New(v)
-			newInt.Elem().SetInt(int64(int(randInt)))
-			args = append(args, newInt.Elem())
+			newElem.SetInt(int64(int(randInt)))
 		case "int8":
 			randInt, err := fuzzConsumer.GetByte()
 			if err != nil {
 				return
 			}
-			newInt := reflect.New(v)
-			newInt.Elem().SetInt(int64(randInt))
-			args = append(args, newInt.Elem())
+			newElem.SetInt(int64(randInt))
 		case "int16":
 			randInt, err := fuzzConsumer.GetUint16()
 			if err != nil {
 				return
 			}
-			newInt := reflect.New(v)
-			newInt.Elem().SetInt(int64(randInt))
-			args = append(args, newInt.Elem())
+			newElem.SetInt(int64(randInt))
 		case "int32":
 			randInt, err := fuzzConsumer.GetUint32()
 			if err != nil {
 				return
 			}
-			newInt := reflect.New(v)
-			newInt.Elem().SetInt(int64(randInt))
-			args = append(args, newInt.Elem())
+			newElem.SetInt(int64(int32(randInt)))
 		case "int64":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				return
 			}
-			newInt := reflect.New(v)
-			newInt.Elem().SetInt(int64(randInt))
-			args = append(args, newInt.Elem())
+			newElem.SetInt(int64(randInt))
 		case "uint":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				return
 			}
-			newUint := reflect.New(v)
-			newUint.Elem().SetUint(uint64(uint(randInt)))
-			args = append(args, newUint.Elem())
+			newElem.SetUint(uint64(uint(randInt)))
 		case "uint8":
 			randInt, err := fuzzConsumer.GetByte()
 			if err != nil {
 				return
 			}
-			newUint := reflect.New(v)
-			newUint.Elem().SetUint(uint64(randInt))
-			args = append(args, newUint.Elem())
+			newElem.SetUint(uint64(randInt))
 		case "uint16":
 			randInt, err := fuzzConsumer.GetUint16()
 			if err != nil {
 				return
 			}
-			newUint16 := reflect.New(v)
-			newUint16.Elem().SetUint(uint64(randInt))
-			args = append(args, newUint16.Elem())
+			newElem.SetUint(uint64(randInt))
 		case "uint32":
 			randInt, err := fuzzConsumer.GetUint32()
 			if err != nil {
 				return
 			}
-			newUint32 := reflect.New(v)
-			newUint32.Elem().SetUint(uint64(randInt))
-			args = append(args, newUint32.Elem())
+			newElem.SetUint(uint64(randInt))
 		case "uint64":
 			randInt, err := fuzzConsumer.GetUint64()
 			if err != nil {
 				return
 			}
-			newUint64 := reflect.New(v)
-			newUint64.Elem().SetUint(uint64(randInt))
-			args = append(args, newUint64.Elem())
+			newElem.SetUint(uint64(randInt))
 		case "rune":
 			randRune, err := fuzzConsumer.GetRune()
 			if err != nil {
 				return
 			}
-			newRune := reflect.New(v)
-			newRune.Elem().Set(reflect.ValueOf(randRune))
-			args = append(args, newRune.Elem())
+			newElem.Set(reflect.ValueOf(randRune))
 		case "float32":
 			randFloat, err := fuzzConsumer.GetFloat32()
 			if err != nil {
 				return
 			}
-			newFloat := reflect.New(v)
-			newFloat.Elem().Set(reflect.ValueOf(randFloat))
-			args = append(args, newFloat.Elem())
+			newElem.Set(reflect.ValueOf(randFloat))
 		case "float64":
 			randFloat, err := fuzzConsumer.GetFloat64()
 			if err != nil {
 				return
 			}
-			newFloat := reflect.New(v)
-			newFloat.Elem().Set(reflect.ValueOf(randFloat))
-			args = append(args, newFloat.Elem())
+			newElem.Set(reflect.ValueOf(randFloat))
 		case "bool":
 			randBool, err := fuzzConsumer.GetBool()
 			if err != nil {
 				return
 			}
-			newBool := reflect.New(v)
-			newBool.Elem().Set(reflect.ValueOf(randBool))
-			args = append(args, newBool.Elem())
+			newElem.Set(reflect.ValueOf(randBool))
 		default:
 			panic(fmt.Sprintf("unsupported type: %s", v.String()))
 		}
+		args = append(args, newElem)
+
 	}
 	fn.Call(args)
 }

--- a/testing/f.go
+++ b/testing/f.go
@@ -41,6 +41,7 @@ func (f *F) Fuzz(ff any) {
 	args := []reflect.Value{reflect.ValueOf(f.T)}
 	fuzzConsumer := fuzz.NewConsumer(f.Data)
 	for _, v := range types {
+		//fmt.Printf("arg %v\n", v)
 		switch v.String() {
 		case "[]uint8":
 			b, err := fuzzConsumer.GetBytes()

--- a/testing/f_test.go
+++ b/testing/f_test.go
@@ -48,7 +48,7 @@ func TestFuzz(t *testing.T) {
 		f uint, g uint8, h uint16, i uint32, j uint64,
 		k string, l []byte,
 		m float64, n float32, o bool, p rune) {
-		have = fmt.Sprint(a, b, c, d, e, f, g, h, i, j, m, n, o, p)
+		have = fmt.Sprint(a, b, c, d, e, f, g, h, i, j, k, string(l), m, n, o, p)
 	}
 
 	f := new(F)
@@ -78,7 +78,7 @@ func TestFuzz(t *testing.T) {
 
 	f.Data = input
 	f.Fuzz(fuzzFunc)
-	want := "-1 -1 -1 -1 -1 1234605616150177399 17 8755 1146447479 1234605616150177399 1.1337 3.14159 true 3"
+	want := "-1 -1 -1 -1 -1 1234605616150177399 17 8755 1146447479 1234605616150177399string\x00oll\nkorrektbytes\x00oll\nkorrekt1.1337 3.14159 true 3"
 	if have != want {
 		t.Fatalf("result wrong\nhave %q\nwant %q", have, want)
 	}

--- a/testing/f_test.go
+++ b/testing/f_test.go
@@ -1,0 +1,91 @@
+package testing
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"testing"
+)
+
+// addString adds a string to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addString(input []byte, s string) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(len(s))) // Add a uint32 length
+	input = append(input, []byte(s)...)                          // Add string
+	return input
+}
+
+// addBytes adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addBytes(input []byte, data []byte) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(len(data))) // Add a uint32 length
+	input = append(input, data...)                                  // Add string
+	return input
+}
+
+// addU64 adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
+func addU64(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint64(input, i)
+	input = append(input, 1) // endianness boolean
+	return input
+}
+
+func addU16(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint16(input, uint16(i))
+	input = append(input, 1) // endianness boolean
+	return input
+}
+
+func addU32(input []byte, i uint64) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(i))
+	// U32 doesn't use endianness boolean! (but when used for float32, it does, sigh)
+	return input
+}
+
+func addF32(input []byte, f float32) []byte {
+	input = binary.BigEndian.AppendUint32(input, uint32(math.Float32bits(f)))
+	input = append(input, 1) // endianness boolean
+	return input
+}
+
+func TestFuzz(t *testing.T) {
+	var have string = "not invoked"
+
+	fuzzFunc := func(t *T,
+		a int, b int8, c int16, d int32, e int64,
+		f uint, g uint8, h uint16, i uint32, j uint64,
+		k string, l []byte,
+		m float64, n float32, o bool, p rune) {
+		have = fmt.Sprint(a, b, c, d, e, f, g, h, i, j, m, n, o, p)
+	}
+
+	f := new(F)
+	var v int64 = -1
+	input := addU64(nil, uint64(v))         // int
+	input = append(input, byte(int8(v)))    // int8
+	input = addU16(input, uint64(int16(v))) // int16
+	input = addU32(input, uint64(int32(v))) // int32
+	input = addU64(input, uint64(int64(v))) // int64
+
+	input = addU64(input, uint64(0x1122_3344_4455_6677)) // uint
+	input = append(input, 0x11)                          // uint8
+	input = addU16(input, uint64(uint16(0x2233)))        // uint16
+	input = addU32(input, uint64(uint32(0x4455_6677)))   // uint32
+	input = addU64(input, uint64(0x1122_3344_4455_6677)) // uint64
+
+	input = addString(input, "string\x00oll\nkorrekt")
+	input = addBytes(input, []byte("bytes\x00oll\nkorrekt"))
+
+	input = addU64(input, math.Float64bits(1.1337)) // float64
+	input = addF32(input, float32(3.14159))         // float32
+
+	input = append(input, 0) // boolean true
+	// Note: the fuzzer doesn't treat runes correctly, instead of a rune being a
+	// rune, it treats them as strings.
+	input = addString(input, string([]rune{rune('Ⅷ')})) // rune
+
+	f.Data = input
+	f.Fuzz(fuzzFunc)
+	want := "-1 -1 -1 -1 -1 1234605616150177399 17 8755 1146447479 1234605616150177399 1.1337 3.14159 true 3"
+	if have != want {
+		t.Fatalf("result wrong\nhave %q\nwant %q", have, want)
+	}
+}

--- a/testing/f_test.go
+++ b/testing/f_test.go
@@ -10,40 +10,34 @@ import (
 // addString adds a string to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addString(input []byte, s string) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(len(s))) // Add a uint32 length
-	input = append(input, []byte(s)...)                          // Add string
-	return input
+	return append(input, []byte(s)...)                           // Add string
 }
 
 // addBytes adds a []byte to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addBytes(input []byte, data []byte) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(len(data))) // Add a uint32 length
-	input = append(input, data...)                                  // Add string
-	return input
+	return append(input, data...)                                   // Add string
 }
 
 // addU64 adds a uint64 to the input vector corresponding to consumer.go @ go-fuzz-headers
 func addU64(input []byte, i uint64) []byte {
 	input = binary.BigEndian.AppendUint64(input, i)
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness booleans
 }
 
 func addU16(input []byte, i uint64) []byte {
 	input = binary.BigEndian.AppendUint16(input, uint16(i))
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness boolean
 }
 
 func addU32(input []byte, i uint64) []byte {
-	input = binary.BigEndian.AppendUint32(input, uint32(i))
 	// U32 doesn't use endianness boolean! (but when used for float32, it does, sigh)
-	return input
+	return binary.BigEndian.AppendUint32(input, uint32(i))
 }
 
 func addF32(input []byte, f float32) []byte {
 	input = binary.BigEndian.AppendUint32(input, uint32(math.Float32bits(f)))
-	input = append(input, 1) // endianness boolean
-	return input
+	return append(input, 1) // endianness boolean
 }
 
 func TestFuzz(t *testing.T) {


### PR DESCRIPTION
This is still a bit work in progress, but it fixes a failing testcase in the coverage package. 
It also updates a dependency, previously, the `GetString` was broken and fixed here: https://github.com/AdaLogics/go-fuzz-headers/commit/fc0ce66dbb85eaefedb39fe334ed4101326fb903#diff-085e2330bdc0dc205f33ed49007f53508335e847bd122d70b29ba8835349bc82R624 . The currently used version would always return a string where the initial byte was taken from the length-byte, which limits the possible values a fuzzed string can have. 

This PR also applies the same fixes to allow full range signed ints as my previous PR uses. I plan to add a few more testcases. 