### PR TITLE
Add testing.TB interface

### DIFF
--- a/testing/f.go
+++ b/testing/f.go
@@ -1,10 +1,13 @@
 package testing
 
 import (
+	"context"
 	"fmt"
-	fuzz "github.com/AdaLogics/go-fuzz-headers"
+	"io"
 	"os"
 	"reflect"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
 type F struct {
@@ -12,6 +15,15 @@ type F struct {
 	T        *T
 	FuzzFunc func(*T, any)
 }
+
+func (f *F) Attr(key, value string) {}
+func (f *F) Chdir(dir string) {
+	f.T.Chdir(dir)
+}
+
+func (f *F) Context() context.Context { return context.Background() }
+
+func (f *F) Output() io.Writer { return os.Stdout }
 
 func (f *F) CleanupTempDirs() {
 	f.T.CleanupTempDirs()

--- a/testing/t.go
+++ b/testing/t.go
@@ -1,7 +1,9 @@
 package testing
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -126,4 +128,18 @@ func (t *T) CleanupTempDirs() {
 			os.RemoveAll(tempDir)
 		}
 	}
+}
+
+func (t *T) Attr(key, value string) {}
+
+func (t *T) Chdir(dir string) {
+	panic(unsupportedApi("t.Chdir()"))
+}
+
+func (t *T) Context() context.Context {
+	return context.Background()
+}
+
+func (t *T) Output() io.Writer {
+	return os.Stdout
 }

--- a/testing/tb.go
+++ b/testing/tb.go
@@ -1,0 +1,26 @@
+package testing
+
+var _ TB = (*T)(nil)
+var _ TB = (*F)(nil)
+
+// TB is the interface common to T, B, and F.
+type TB interface {
+	Cleanup(func())
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Helper()
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Setenv(key, value string)
+	Skip(args ...any)
+	SkipNow()
+	Skipf(format string, args ...any)
+	Skipped() bool
+	TempDir() string
+}

--- a/testing/tb_go1.25.go
+++ b/testing/tb_go1.25.go
@@ -1,12 +1,18 @@
-//go:build !go1.25
+//go:build go1.25
 
 package testing
+
+import (
+	"context"
+	"io"
+)
 
 var _ TB = (*T)(nil)
 var _ TB = (*F)(nil)
 
 // TB is the interface common to T, B, and F.
 type TB interface {
+	Attr(key, value string)
 	Cleanup(func())
 	Error(args ...any)
 	Errorf(format string, args ...any)
@@ -20,9 +26,12 @@ type TB interface {
 	Logf(format string, args ...any)
 	Name() string
 	Setenv(key, value string)
+	Chdir(dir string)
 	Skip(args ...any)
 	SkipNow()
 	Skipf(format string, args ...any)
 	Skipped() bool
 	TempDir() string
+	Context() context.Context
+	Output() io.Writer
 }


### PR DESCRIPTION
Fixes `internal/fuzz/helpers.go:100:31: undefined: testing.TB`

Asserts that *T and *F supports the interface.