### PR TITLE
Support t.Skip("GO-FUZZ-UNINTERESTING") to signal uninteresting inputs

### DIFF
--- a/file_walker.go
+++ b/file_walker.go
@@ -82,15 +82,24 @@ func (c *F) Logf(format string, args ...any) {
 func (c *F) Name() string             { return "libFuzzer" }
 func (c *F) Setenv(key, value string) {}
 func (c *F) Skip(args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(args...))
 }
 func (c *F) SkipNow() {
 	panic("GO-FUZZ-BUILD-PANIC")
 }
 func (c *F) Skipf(format string, args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(format))
 }
 func (f *F) Skipped() bool { return false }
+
+func skipMessage(args ...any) string {
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && s == "GO-FUZZ-UNINTERESTING" {
+			return "GO-FUZZ-UNINTERESTING"
+		}
+	}
+	return "GO-FUZZ-BUILD-PANIC"
+}
 
 func (f *F) TempDir() string {
 	dir, err := os.MkdirTemp("", "fuzzdir-")
@@ -861,9 +870,9 @@ var (
 		"func (t *T) Parallel() {":                               "func (t *T) Parallel() {\npanic(\"t.Parallel()\")",
 		"func (t *T) Run(name string, f func(t *T)) bool {":      "func (t *T) Run(name string, f func(t *T)) bool {\nf(t)\nreturn true",
 		////////"func (c *common) Setenv(key, value string) {": "func (c *common) Setenv(key, value string) {\n"
-		"func (c *common) Skip(args ...any) {":    "func (c *common) Skip(args ...any) {\npanic(\"GO-FUZZ-BUILD-PANIC\")",
+		"func (c *common) Skip(args ...any) {":    "func (c *common) Skip(args ...any) {\nfor _, arg := range args {\nif s, ok := arg.(string); ok && s == \"GO-FUZZ-UNINTERESTING\" {\npanic(\"GO-FUZZ-UNINTERESTING\")\n}\n}\npanic(\"GO-FUZZ-BUILD-PANIC\")",
 		"func (c *common) SkipNow(args ...any) {": "func (c *common) SkipNow(args ...any) {\npanic(\"GO-FUZZ-BUILD-PANIC\")",
-		"func (c *common) Skipf(args ...any) {":   "func (c *common) Skipf(args ...any) {\npanic(\"GO-FUZZ-BUILD-PANIC\")",
+		"func (c *common) Skipf(args ...any) {":   "func (c *common) Skipf(args ...any) {\nif len(args) > 0 {\nif s, ok := args[0].(string); ok && s == \"GO-FUZZ-UNINTERESTING\" {\npanic(\"GO-FUZZ-UNINTERESTING\")\n}\n}\npanic(\"GO-FUZZ-BUILD-PANIC\")",
 		"func (c *common) Skipped() bool {":       "func (c *common) Skipped() bool {\npanic(\"t.Skipped()\")",
 		"type T struct {":                         "type T struct {\ntempDirsParentDir string",
 		//"func (c *common) TempDir() string {": "func (c *common) TempDir() string {\ntmpFuzzDir, err := os.MkdirTemp(c.tempDirsParentDir, \"fuzzdir-\")\nif err != nil {\npanic(err)\n}\nreturn tmpFuzzDir",

--- a/file_walker_test.go
+++ b/file_walker_test.go
@@ -426,6 +426,11 @@ return true
 			source: `func (c *common) Skip(args ...any) {
 }`,
 			expected: `func (c *common) Skip(args ...any) {
+for _, arg := range args {
+if s, ok := arg.(string); ok && s == "GO-FUZZ-UNINTERESTING" {
+panic("GO-FUZZ-UNINTERESTING")
+}
+}
 panic("GO-FUZZ-BUILD-PANIC")
 }`,
 		},
@@ -440,6 +445,11 @@ panic("GO-FUZZ-BUILD-PANIC")
 			source: `func (c *common) Skipf(args ...any) {
 }`,
 			expected: `func (c *common) Skipf(args ...any) {
+if len(args) > 0 {
+if s, ok := args[0].(string); ok && s == "GO-FUZZ-UNINTERESTING" {
+panic("GO-FUZZ-UNINTERESTING")
+}
+}
 panic("GO-FUZZ-BUILD-PANIC")
 }`,
 		},

--- a/main.go
+++ b/main.go
@@ -259,9 +259,11 @@ import (
 import "C"
 
 //export LLVMFuzzerTestOneInput
-func LLVMFuzzerTestOneInput(data *C.char, size C.size_t) C.int {
+func LLVMFuzzerTestOneInput(data *C.char, size C.size_t) (ret C.int) {
 	s := (*[1<<30]byte)(unsafe.Pointer(data))[:size:size]
-	defer catchPanics()
+	defer func() {
+		ret = C.int(catchPanics())
+	}()
 	LibFuzzer{{.Func}}(s)
 	return 0
 }
@@ -273,7 +275,7 @@ func LibFuzzer{{.Func}}(data []byte) int {
 	return 1
 }
 
-func catchPanics() {
+func catchPanics() int {
 	if r := recover(); r != nil {
 		var err string
 		switch r.(type) {
@@ -284,12 +286,15 @@ func catchPanics() {
 		case error:
 			err = r.(error).Error()
 		}
-		if strings.Contains(err, "GO-FUZZ-BUILD-PANIC") {
-			return
-		} else {
-			panic(err)
+		if strings.Contains(err, "GO-FUZZ-UNINTERESTING") {
+			return -1
 		}
+		if strings.Contains(err, "GO-FUZZ-BUILD-PANIC") {
+			return 0
+		}
+		panic(err)
 	}
+	return 0
 }
 
 func main() {

--- a/testing/f.go
+++ b/testing/f.go
@@ -45,13 +45,13 @@ func (c *F) Logf(format string, args ...any) {
 func (c *F) Name() string             { return "libFuzzer" }
 func (c *F) Setenv(key, value string) {}
 func (c *F) Skip(args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(args...))
 }
 func (c *F) SkipNow() {
 	panic("GO-FUZZ-BUILD-PANIC")
 }
 func (c *F) Skipf(format string, args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(format))
 }
 func (f *F) Skipped() bool { return false }
 

--- a/testing/t.go
+++ b/testing/t.go
@@ -100,17 +100,25 @@ func (t *T) Setenv(key, value string) {
 }
 
 func (t *T) Skip(args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(args...))
 }
 func (t *T) SkipNow() {
 	panic("GO-FUZZ-BUILD-PANIC")
 }
-
-// Is not really supported. We just skip instead
-// of printing any message. A log message can be
-// added if need be.
 func (t *T) Skipf(format string, args ...any) {
-	panic("GO-FUZZ-BUILD-PANIC")
+	panic(skipMessage(format))
+}
+
+// skipMessage returns "GO-FUZZ-UNINTERESTING" if any argument equals that
+// string, signalling to the fuzzer that the input should be discarded from
+// the corpus. Otherwise it returns "GO-FUZZ-BUILD-PANIC".
+func skipMessage(args ...any) string {
+	for _, arg := range args {
+		if s, ok := arg.(string); ok && s == "GO-FUZZ-UNINTERESTING" {
+			return "GO-FUZZ-UNINTERESTING"
+		}
+	}
+	return "GO-FUZZ-BUILD-PANIC"
 }
 func (t *T) Skipped() bool {
 	panic(unsupportedApi("t.Skipped()"))


### PR DESCRIPTION
When a fuzz target calls t.Skip("GO-FUZZ-UNINTERESTING"), the generated LLVMFuzzerTestOneInput now returns -1, which instructs libFuzzer to discard the input from the corpus. This allows fuzz targets to filter out inputs that are syntactically valid but semantically uninteresting.